### PR TITLE
Add three new SVG icon files

### DIFF
--- a/icon-svg/maxxair-fan.delux-closed.svg
+++ b/icon-svg/maxxair-fan.delux-closed.svg
@@ -1,17 +1,1 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<!-- Created with Inkscape (http://www.inkscape.org/) -->
-<!-- path d="..." is unique for each icon -->
-
-<svg
-   width="24"
-   height="24"
-   viewBox="0 0 24 24"
-   version="1.1"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:svg="http://www.w3.org/2000/svg">
-   <path
-     style="fill:#44739e"
-     d="M20.01,11.65H0l1-3.79c6.67-1.7,11.34-1.7,18.01,0l1,3.79Z"/>
-  <rect style="fill:#44739e" x="2.44" y="10.65" width="11.35" height="2.37"/>
-  <rect style="fill:#44739e" x="1.82" y="12.34" width="12.59" height=".68"/>
-</svg>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path fill="#44739e" d="M22 13.847H2l1-3.789c6.666-1.699 11.334-1.699 18 0Z"/><path fill="#44739e" d="M4.439 12.847h11.344v2.369H4.439Z"/><path fill="#44739e" d="M3.819 14.536h12.584v.68H3.819Z"/></svg>

--- a/icon-svg/maxxair-fan.delux-closed.svg
+++ b/icon-svg/maxxair-fan.delux-closed.svg
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+<!-- path d="..." is unique for each icon -->
+
+<svg
+   width="24"
+   height="24"
+   viewBox="0 0 24 24"
+   version="1.1"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+   <path
+     style="fill:#44739e"
+     d="M20.01,11.65H0l1-3.79c6.67-1.7,11.34-1.7,18.01,0l1,3.79Z"/>
+  <rect style="fill:#44739e" x="2.44" y="10.65" width="11.35" height="2.37"/>
+  <rect style="fill:#44739e" x="1.82" y="12.34" width="12.59" height=".68"/>
+</svg>

--- a/icon-svg/maxxair-fan.delux-open.svg
+++ b/icon-svg/maxxair-fan.delux-open.svg
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+<!-- path d="..." is unique for each icon -->
+
+<svg
+   width="24"
+   height="24"
+   viewBox="0 0 24 24"
+   version="1.1"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+   <path style="fill:#44739e" d="M18.78,2.98l-3.88,4.99L.74,11.63,0,7.78C5.28,3.36,9.49,1.34,16.24,0l2.54,2.98Z"/>
+  <polygon style="fill:#44739e" points="13.79 13.01 2.44 13.01 2.44 10.65 13.79 5.65 13.79 13.01"/>
+  <rect style="fill:#44739e" x="1.82" y="12.34" width="12.59" height=".68"/>
+</svg>

--- a/icon-svg/maxxair-fan.delux-open.svg
+++ b/icon-svg/maxxair-fan.delux-open.svg
@@ -1,15 +1,1 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<!-- Created with Inkscape (http://www.inkscape.org/) -->
-<!-- path d="..." is unique for each icon -->
-
-<svg
-   width="24"
-   height="24"
-   viewBox="0 0 24 24"
-   version="1.1"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:svg="http://www.w3.org/2000/svg">
-   <path style="fill:#44739e" d="M18.78,2.98l-3.88,4.99L.74,11.63,0,7.78C5.28,3.36,9.49,1.34,16.24,0l2.54,2.98Z"/>
-  <polygon style="fill:#44739e" points="13.79 13.01 2.44 13.01 2.44 10.65 13.79 5.65 13.79 13.01"/>
-  <rect style="fill:#44739e" x="1.82" y="12.34" width="12.59" height=".68"/>
-</svg>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path fill="#44739e" d="m22 8.241-4.132 5.314-15.08 3.898-.788-4.1c5.623-4.708 10.106-6.859 17.295-8.286Z"/><path fill="#44739e" d="M16.686 18.922H4.599v-2.513l12.087-5.325Z"/><path fill="#44739e" d="M3.938 18.209h13.408v.724H3.938Z"/></svg>

--- a/icon-svg/prescolite.svg
+++ b/icon-svg/prescolite.svg
@@ -1,0 +1,3 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+<svg width="24" height="24" version="1.1" viewBox="0 0 6.35 6.35" xml:space="preserve" xmlns="http://www.w3.org/2000/svg"><g stroke="#44739e" stroke-linecap="square" stroke-linejoin="round"><path d="m1.2673 0.77206 0.022203 4.3555 0.42184 6e-3 0.79928-0.34018-0.14115-2.7711c0.93949-0.16342 1.8554-0.16931 2.6865-0.0635l-0.03647-1.2291c-0.92566-0.17997-1.4024-0.17103-2.4406-6e-3z" fill="#44739e" stop-color="#000000" stroke-width=".025837"/><path d="m2.3914 2.0732 0.1883 3.3563c0.38912 0.50207 2.0761 0.3458 2.2429-0.0379l0.06809-3.4445" fill="none" stop-color="#000000" stroke-width=".25837"/></g></svg>

--- a/icon-svg/prescolite.svg
+++ b/icon-svg/prescolite.svg
@@ -1,3 +1,1 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!-- Created with Inkscape (http://www.inkscape.org/) -->
-<svg width="24" height="24" version="1.1" viewBox="0 0 6.35 6.35" xml:space="preserve" xmlns="http://www.w3.org/2000/svg"><g stroke="#44739e" stroke-linecap="square" stroke-linejoin="round"><path d="m1.2673 0.77206 0.022203 4.3555 0.42184 6e-3 0.79928-0.34018-0.14115-2.7711c0.93949-0.16342 1.8554-0.16931 2.6865-0.0635l-0.03647-1.2291c-0.92566-0.17997-1.4024-0.17103-2.4406-6e-3z" fill="#44739e" stop-color="#000000" stroke-width=".025837"/><path d="m2.3914 2.0732 0.1883 3.3563c0.38912 0.50207 2.0761 0.3458 2.2429-0.0379l0.06809-3.4445" fill="none" stop-color="#000000" stroke-width=".25837"/></g></svg>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path fill="#44739e" d="m3.647 2.767.101 19.207L5.605 22l3.527-1.499-.626-12.222a39.7 39.7 0 0 1 11.847-.278l-.159-5.423c-4.082-.79-6.186-.746-10.762-.018Z"/></svg>


### PR DESCRIPTION
Add three new icons to icon-svg: maxxair-fan.delux-closed.svg, maxxair-fan.delux-open.svg, and prescolite.svg. Icons were created with Inkscape and use the #44739e stroke/fill; they provide open/closed variants for the Maxxair fan and a Prescolite icon for UI use.