### PR TITLE
Add tilt cover/window SVG icons

### DIFF
--- a/icon-svg/tilt-cover-closed.svg
+++ b/icon-svg/tilt-cover-closed.svg
@@ -1,0 +1,75 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="25mm"
+   height="25mm"
+   version="1.1"
+   viewBox="0 0 25 25"
+   id="svg92"
+   sodipodi:docname="roof-cover-closed.svg"
+   inkscape:version="1.2.2 (b0a8486541, 2022-12-01)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <defs
+     id="defs96" />
+  <sodipodi:namedview
+     id="namedview94"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     inkscape:document-units="mm"
+     showgrid="false"
+     inkscape:zoom="5.336971"
+     inkscape:cx="-14.989776"
+     inkscape:cy="53.869507"
+     inkscape:window-width="1920"
+     inkscape:window-height="1022"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="g90" />
+  <g
+     transform="translate(-113.99,-140.8)"
+     stroke-linecap="round"
+     id="g90">
+    <path
+       d="m 124.73917,147.20751 11.368,-0.008 -6.4434,15.664 -11.788,-0.006 z"
+       fill="#ffffff"
+       stroke="#000000"
+       stroke-linejoin="round"
+       stroke-width="1.5"
+       id="path82"
+       style="stroke:#44739e;stroke-opacity:1" />
+    <path
+       d="m 117.91541,159.93155 1.85454,0.008"
+       fill="none"
+       stroke="#ffffff"
+       stroke-linejoin="bevel"
+       stroke-opacity="0.99346"
+       stroke-width="1.89844"
+       id="path84"
+       sodipodi:nodetypes="cc" />
+    <path
+       d="m 127.82339,158.92346 5.3491,-12.742"
+       fill="none"
+       stroke="#ffffff"
+       stroke-linejoin="bevel"
+       stroke-width="0.5"
+       id="path86"
+       style="stroke-width:2.4;stroke-dasharray:none" />
+    <path
+       d="m 122.24917,143.61 11.368,-0.008 -6.4434,15.664 -11.788,-0.006 z"
+       stroke="#000000"
+       stroke-linejoin="round"
+       stroke-width="1.5"
+       id="path88"
+       style="stroke:#44739e;stroke-opacity:1;fill:#44739e;fill-opacity:1" />
+  </g>
+</svg>

--- a/icon-svg/tilt-cover-closing.svg
+++ b/icon-svg/tilt-cover-closing.svg
@@ -1,0 +1,89 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="25mm"
+   height="25mm"
+   version="1.1"
+   viewBox="0 0 25 25"
+   id="svg92"
+   sodipodi:docname="roof-cover-closing.svg"
+   inkscape:version="1.2.2 (b0a8486541, 2022-12-01)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <defs
+     id="defs96" />
+  <sodipodi:namedview
+     id="namedview94"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     inkscape:document-units="mm"
+     showgrid="false"
+     inkscape:zoom="5.8490095"
+     inkscape:cx="0.4274228"
+     inkscape:cy="54.881087"
+     inkscape:window-width="1920"
+     inkscape:window-height="1004"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="g90" />
+  <g
+     transform="translate(-113.99,-140.8)"
+     stroke-linecap="round"
+     id="g90">
+    <path
+       d="m 124.73917,147.20751 11.368,-0.008 -6.4434,15.664 -11.788,-0.006 z"
+       fill="#ffffff"
+       stroke="#000000"
+       stroke-linejoin="round"
+       stroke-width="1.5"
+       id="path82"
+       style="stroke:#44739e;stroke-opacity:1" />
+    <path
+       d="m 123.77013,143.54414 11.368,-0.008 -0.67561,1.45679 -11.3346,0.0331 z"
+       stroke="#000000"
+       stroke-linejoin="round"
+       stroke-width="1.5"
+       id="path88"
+       style="fill:#44739e;fill-opacity:1;stroke:#44739e;stroke-opacity:1"
+       sodipodi:nodetypes="ccccc" />
+    <path
+       d="m 118.06385,151.74358 3.62299,-8.19171"
+       fill="none"
+       stroke="#ffffff"
+       stroke-linejoin="bevel"
+       stroke-opacity="0.99346"
+       stroke-width="1.89844"
+       id="path84-6-3"
+       sodipodi:nodetypes="cc"
+       style="stroke:#44739e;stroke-width:1;stroke-dasharray:none;stroke-opacity:1" />
+    <path
+       d="m 118.07185,151.7545 3.02397,-2.23245"
+       fill="none"
+       stroke="#ffffff"
+       stroke-linejoin="bevel"
+       stroke-opacity="0.99346"
+       stroke-width="1.89844"
+       id="path84-6-7-56"
+       sodipodi:nodetypes="cc"
+       style="stroke:#44739e;stroke-width:1;stroke-dasharray:none;stroke-opacity:1" />
+    <path
+       d="m 118.05607,151.72519 -0.83711,-2.85958"
+       fill="none"
+       stroke="#ffffff"
+       stroke-linejoin="bevel"
+       stroke-opacity="0.99346"
+       stroke-width="1.89844"
+       id="path84-6-7-5-2"
+       sodipodi:nodetypes="cc"
+       style="stroke:#44739e;stroke-width:1;stroke-dasharray:none;stroke-opacity:1" />
+  </g>
+</svg>

--- a/icon-svg/tilt-cover-disabled.svg
+++ b/icon-svg/tilt-cover-disabled.svg
@@ -1,0 +1,75 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="25mm"
+   height="25mm"
+   version="1.1"
+   viewBox="0 0 25 25"
+   id="svg92"
+   sodipodi:docname="roof-cover-closed-disabled.svg"
+   inkscape:version="1.2.2 (b0a8486541, 2022-12-01)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <defs
+     id="defs96" />
+  <sodipodi:namedview
+     id="namedview94"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     inkscape:document-units="mm"
+     showgrid="false"
+     inkscape:zoom="5.336971"
+     inkscape:cx="-17.238242"
+     inkscape:cy="53.869507"
+     inkscape:window-width="1920"
+     inkscape:window-height="1022"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="g90" />
+  <g
+     transform="translate(-113.99,-140.8)"
+     stroke-linecap="round"
+     id="g90">
+    <path
+       d="m 124.73917,147.20751 11.368,-0.008 -6.4434,15.664 -11.788,-0.006 z"
+       fill="#ffffff"
+       stroke="#000000"
+       stroke-linejoin="round"
+       stroke-width="1.5"
+       id="path82"
+       style="stroke:#bdbdbd;stroke-opacity:1" />
+    <path
+       d="m 117.91541,159.93155 1.85454,0.008"
+       fill="none"
+       stroke="#ffffff"
+       stroke-linejoin="bevel"
+       stroke-opacity="0.99346"
+       stroke-width="1.89844"
+       id="path84"
+       sodipodi:nodetypes="cc" />
+    <path
+       d="m 127.82339,158.92346 5.3491,-12.742"
+       fill="none"
+       stroke="#ffffff"
+       stroke-linejoin="bevel"
+       stroke-width="0.5"
+       id="path86"
+       style="stroke-width:2.4;stroke-dasharray:none" />
+    <path
+       d="m 122.24917,143.61 11.368,-0.008 -6.4434,15.664 -11.788,-0.006 z"
+       stroke="#000000"
+       stroke-linejoin="round"
+       stroke-width="1.5"
+       id="path88"
+       style="stroke:#bdbdbd;stroke-opacity:1;fill:#bdbdbd;fill-opacity:1" />
+  </g>
+</svg>

--- a/icon-svg/tilt-cover-opened.svg
+++ b/icon-svg/tilt-cover-opened.svg
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="25mm"
+   height="25mm"
+   version="1.1"
+   viewBox="0 0 25 25"
+   id="svg92"
+   sodipodi:docname="roof-cover-open.svg"
+   inkscape:version="1.2.2 (b0a8486541, 2022-12-01)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <defs
+     id="defs96" />
+  <sodipodi:namedview
+     id="namedview94"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     inkscape:document-units="mm"
+     showgrid="false"
+     inkscape:zoom="2.5826895"
+     inkscape:cx="-85.182521"
+     inkscape:cy="38.138538"
+     inkscape:window-width="1920"
+     inkscape:window-height="1022"
+     inkscape:window-x="1920"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="g90" />
+  <g
+     transform="translate(-113.99,-140.8)"
+     stroke-linecap="round"
+     id="g90">
+    <path
+       d="m 124.73917,147.20751 11.368,-0.008 -6.4434,15.664 -11.788,-0.006 z"
+       fill="#ffffff"
+       stroke="#000000"
+       stroke-linejoin="round"
+       stroke-width="1.5"
+       id="path82"
+       style="stroke:#44739e;stroke-opacity:1" />
+    <path
+       d="m 123.77013,143.54414 11.368,-0.008 -0.67561,1.45679 -11.3346,0.0331 z"
+       stroke="#000000"
+       stroke-linejoin="round"
+       stroke-width="1.5"
+       id="path88"
+       style="fill:#44739e;fill-opacity:1;stroke:#44739e;stroke-opacity:1"
+       sodipodi:nodetypes="ccccc" />
+  </g>
+</svg>

--- a/icon-svg/tilt-cover-opening.svg
+++ b/icon-svg/tilt-cover-opening.svg
@@ -1,0 +1,105 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="25mm"
+   height="25mm"
+   version="1.1"
+   viewBox="0 0 25 25"
+   id="svg92"
+   sodipodi:docname="roof-cover-opening.svg"
+   inkscape:version="1.2.2 (b0a8486541, 2022-12-01)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <defs
+     id="defs96" />
+  <sodipodi:namedview
+     id="namedview94"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     inkscape:document-units="mm"
+     showgrid="false"
+     inkscape:zoom="3.7062966"
+     inkscape:cx="29.004694"
+     inkscape:cy="-5.3962222"
+     inkscape:window-width="1920"
+     inkscape:window-height="1004"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="g90" />
+  <g
+     transform="translate(-113.99,-140.8)"
+     stroke-linecap="round"
+     id="g90">
+    <path
+       d="m 124.73917,147.20751 11.368,-0.008 -6.4434,15.664 -11.788,-0.006 z"
+       fill="#ffffff"
+       stroke="#000000"
+       stroke-linejoin="round"
+       stroke-width="1.5"
+       id="path82"
+       style="stroke:#44739e;stroke-opacity:1" />
+    <path
+       d="m 117.91541,159.93155 1.85454,0.008"
+       fill="none"
+       stroke="#ffffff"
+       stroke-linejoin="bevel"
+       stroke-opacity="0.99346"
+       stroke-width="1.89844"
+       id="path84"
+       sodipodi:nodetypes="cc" />
+    <path
+       d="m 127.82339,158.92346 5.3491,-12.742"
+       fill="none"
+       stroke="#ffffff"
+       stroke-linejoin="bevel"
+       stroke-width="0.5"
+       id="path86"
+       style="stroke-width:2.4;stroke-dasharray:none" />
+    <path
+       d="m 122.24917,143.61 11.368,-0.008 -6.4434,15.664 -11.788,-0.006 z"
+       stroke="#000000"
+       stroke-linejoin="round"
+       stroke-width="1.5"
+       id="path88"
+       style="stroke:#44739e;stroke-opacity:1;fill:#44739e;fill-opacity:1" />
+    <path
+       d="m 123.02449,155.07381 3.62299,-8.19171"
+       fill="none"
+       stroke="#ffffff"
+       stroke-linejoin="bevel"
+       stroke-opacity="0.99346"
+       stroke-width="1.89844"
+       id="path84-6"
+       sodipodi:nodetypes="cc"
+       style="stroke-width:1;stroke-dasharray:none" />
+    <path
+       d="m 123.51653,149.14066 3.02398,-2.23245"
+       fill="none"
+       stroke="#ffffff"
+       stroke-linejoin="bevel"
+       stroke-opacity="0.99346"
+       stroke-width="1.89844"
+       id="path84-6-7"
+       sodipodi:nodetypes="cc"
+       style="stroke-width:1;stroke-dasharray:none" />
+    <path
+       d="m 127.5263,149.75026 -0.83711,-2.85958"
+       fill="none"
+       stroke="#ffffff"
+       stroke-linejoin="bevel"
+       stroke-opacity="0.99346"
+       stroke-width="1.89844"
+       id="path84-6-7-5"
+       sodipodi:nodetypes="cc"
+       style="stroke-width:1;stroke-dasharray:none" />
+  </g>
+</svg>

--- a/icon-svg/tilt-window-closing.svg
+++ b/icon-svg/tilt-window-closing.svg
@@ -1,0 +1,124 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="25mm"
+   height="25mm"
+   viewBox="0 0 25 24.999999"
+   version="1.1"
+   id="svg5804"
+   inkscape:version="1.2.2 (b0a8486541, 2022-12-01)"
+   sodipodi:docname="roof-window-closing.svg"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <sodipodi:namedview
+     id="namedview5806"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     inkscape:document-units="mm"
+     showgrid="false"
+     inkscape:zoom="13.566073"
+     inkscape:cx="70.359345"
+     inkscape:cy="59.707773"
+     inkscape:window-width="1920"
+     inkscape:window-height="1004"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="layer1" />
+  <defs
+     id="defs5801" />
+  <g
+     inkscape:label="Ebene 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(-113.98819,-140.80081)">
+    <path
+       id="rect323-3"
+       style="fill:#ffffff;stroke:#44739e;stroke-width:1.5;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1"
+       d="m 124.2135,145.62023 11.36755,-0.008 -6.44343,15.66394 -11.78758,-0.006 z"
+       sodipodi:nodetypes="ccccc" />
+    <path
+       style="fill:none;stroke:#ffffff;stroke-width:0.5;stroke-linecap:round;stroke-linejoin:bevel;stroke-dasharray:none;stroke-opacity:1"
+       d="m 117.9463,156.98619 3.08946,-0.003"
+       id="path1624-5-3-2"
+       sodipodi:nodetypes="cc" />
+    <path
+       style="fill:none;stroke:#ffffff;stroke-width:0.5;stroke-linecap:round;stroke-linejoin:bevel;stroke-dasharray:none;stroke-opacity:1"
+       d="m 117.12532,158.98194 3.08946,-0.003"
+       id="path1624-5-3-2-9"
+       sodipodi:nodetypes="cc" />
+    <path
+       style="fill:none;stroke:#44739e;stroke-width:0.989001;stroke-linecap:round;stroke-linejoin:bevel;stroke-dasharray:none;stroke-opacity:1"
+       d="m 130.08944,150.66682 0.66825,-0.0143"
+       id="path1624-5-3-2-9-6"
+       sodipodi:nodetypes="cc" />
+    <path
+       id="rect323-3-6"
+       style="fill:none;stroke:#44739e;stroke-width:1.5;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;paint-order:normal;stroke-opacity:1"
+       d="m 126.40518,149.01656 11.80733,-0.0256 -10.66445,8.99472 -12.71556,-0.006 z"
+       sodipodi:nodetypes="ccccc" />
+    <path
+       style="fill:none;stroke:#b6b6b6;stroke-width:0;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1"
+       d="m 119.99244,152.89751 4.42955,-4.2264"
+       id="path1624"
+       sodipodi:nodetypes="cc" />
+    <path
+       style="fill:none;stroke:#ffffff;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1"
+       d="m 118.59553,153.79793 5.29941,-4.09257"
+       id="path1624-5"
+       sodipodi:nodetypes="cc" />
+    <path
+       style="fill:none;stroke:#ffffff;stroke-width:0.5;stroke-linecap:round;stroke-linejoin:bevel;stroke-dasharray:none;stroke-opacity:1"
+       d="m 118.29956,156.54888 4.91708,-3.81295"
+       id="path1624-5-3"
+       sodipodi:nodetypes="cc" />
+    <path
+       style="fill:none;stroke:#ffffff;stroke-width:0.5;stroke-linecap:round;stroke-linejoin:bevel;stroke-dasharray:none;stroke-opacity:1"
+       d="m 128.60176,159.95723 5.29854,-12.87884"
+       id="path1624-5-3-1"
+       sodipodi:nodetypes="cc" />
+    <path
+       style="fill:none;stroke:#ffffff;stroke-width:0.5;stroke-linecap:round;stroke-linejoin:bevel;stroke-dasharray:none;stroke-opacity:1"
+       d="m 132.36083,156.06563 3.84282,-9.30478"
+       id="path1624-5-3-1-2"
+       sodipodi:nodetypes="cc" />
+    <path
+       d="m 134.45596,159.74289 c 2.2087,-1.51534 2.66432,-3.61804 1.18959,-5.64564"
+       fill="none"
+       stroke="#ffffff"
+       stroke-linejoin="bevel"
+       stroke-opacity="0.99346"
+       stroke-width="1.89844"
+       id="path84-6-3"
+       sodipodi:nodetypes="cc"
+       style="stroke:#44739e;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1" />
+    <path
+       d="m 134.5324,156.58231 1.11141,-2.53043"
+       fill="none"
+       stroke="#ffffff"
+       stroke-linejoin="bevel"
+       stroke-opacity="0.99346"
+       stroke-width="1.89844"
+       id="path84-6-7-56"
+       sodipodi:nodetypes="cc"
+       style="stroke:#44739e;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1" />
+    <path
+       d="m 138.42557,155.26865 -2.68972,-1.21345"
+       fill="none"
+       stroke="#ffffff"
+       stroke-linejoin="bevel"
+       stroke-opacity="0.99346"
+       stroke-width="1.89844"
+       id="path84-6-7-5-2"
+       sodipodi:nodetypes="cc"
+       style="stroke:#44739e;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1" />
+  </g>
+</svg>

--- a/icon-svg/tilt-window-disabled.svg
+++ b/icon-svg/tilt-window-disabled.svg
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="25mm"
+   height="25mm"
+   version="1.1"
+   viewBox="0 0 25 25"
+   id="svg6"
+   sodipodi:docname="roof-cover-disabled.svg"
+   inkscape:version="1.2.2 (b0a8486541, 2022-12-01)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <defs
+     id="defs10" />
+  <sodipodi:namedview
+     id="namedview8"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     inkscape:document-units="mm"
+     showgrid="false"
+     inkscape:zoom="8.9005833"
+     inkscape:cx="47.075566"
+     inkscape:cy="47.468799"
+     inkscape:window-width="1920"
+     inkscape:window-height="1022"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg6" />
+  <g
+     transform="translate(-113.99 -140.8)"
+     id="g4"
+     style="fill:none;fill-opacity:1;stroke:#bdbdbd;stroke-opacity:1">
+    <path
+       d="m124.21 145.62 11.368-8e-3 -6.4434 15.664-11.788-6e-3z"
+       fill="#fff"
+       stroke="#000"
+       stroke-linecap="round"
+       stroke-linejoin="round"
+       stroke-width="1.5"
+       id="path2"
+       style="fill:none;fill-opacity:1;stroke:#bdbdbd;stroke-opacity:1" />
+  </g>
+</svg>

--- a/icon-svg/tilt-window-opening.svg
+++ b/icon-svg/tilt-window-opening.svg
@@ -1,0 +1,87 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="25mm"
+   height="25mm"
+   version="1.1"
+   viewBox="0 0 25 25"
+   id="svg6"
+   sodipodi:docname="roof-window-opening.svg"
+   inkscape:version="1.2.2 (b0a8486541, 2022-12-01)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <defs
+     id="defs10" />
+  <sodipodi:namedview
+     id="namedview8"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     inkscape:document-units="mm"
+     showgrid="false"
+     inkscape:zoom="8.0754751"
+     inkscape:cx="30.153025"
+     inkscape:cy="60.182217"
+     inkscape:window-width="1920"
+     inkscape:window-height="1004"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg6" />
+  <g
+     transform="translate(-113.99 -140.8)"
+     id="g4"
+     style="fill:none;fill-opacity:1;stroke:#44739e;stroke-opacity:1">
+    <path
+       d="m124.21 145.62 11.368-8e-3 -6.4434 15.664-11.788-6e-3z"
+       fill="#fff"
+       stroke="#000"
+       stroke-linecap="round"
+       stroke-linejoin="round"
+       stroke-width="1.5"
+       id="path2"
+       style="fill:none;fill-opacity:1;stroke:#44739e;stroke-opacity:1" />
+  </g>
+  <path
+     style="fill:none;stroke:#44739e;stroke-width:2.00034;stroke-linecap:round;stroke-linejoin:bevel;stroke-dasharray:none;stroke-opacity:1"
+     d="m 13.460204,7.9223172 2.070306,2.381e-4"
+     id="path1624-5-3-2-9-6"
+     sodipodi:nodetypes="cc" />
+  <path
+     d="m 21.595007,17.153852 c 1.685472,-2.08177 1.523187,-4.227142 -0.46808,-5.750579"
+     fill="none"
+     stroke="#ffffff"
+     stroke-linejoin="bevel"
+     stroke-opacity="0.99346"
+     stroke-width="1.89844"
+     id="path84-6-3"
+     sodipodi:nodetypes="cc"
+     style="stroke:#44739e;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1" />
+  <path
+     d="m 21.465424,17.767575 3.02397,-2.23245"
+     fill="none"
+     stroke="#ffffff"
+     stroke-linejoin="bevel"
+     stroke-opacity="0.99346"
+     stroke-width="1.89844"
+     id="path84-6-7-56"
+     sodipodi:nodetypes="cc"
+     style="stroke:#44739e;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1" />
+  <path
+     d="m 21.449644,17.738265 -0.83711,-2.85958"
+     fill="none"
+     stroke="#ffffff"
+     stroke-linejoin="bevel"
+     stroke-opacity="0.99346"
+     stroke-width="1.89844"
+     id="path84-6-7-5-2"
+     sodipodi:nodetypes="cc"
+     style="stroke:#44739e;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1" />
+</svg>

--- a/icon-svg/tilt-window-venting.svg
+++ b/icon-svg/tilt-window-venting.svg
@@ -1,0 +1,63 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="25mm"
+   height="25mm"
+   viewBox="0 0 25 24.999999"
+   version="1.1"
+   id="svg5804"
+   inkscape:version="1.2.2 (b0a8486541, 2022-12-01)"
+   sodipodi:docname="roof-window-venting.svg"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <sodipodi:namedview
+     id="namedview5806"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     inkscape:document-units="mm"
+     showgrid="false"
+     inkscape:zoom="4.6284395"
+     inkscape:cx="13.07136"
+     inkscape:cy="44.07533"
+     inkscape:window-width="1920"
+     inkscape:window-height="1004"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="layer1" />
+  <defs
+     id="defs5801" />
+  <g
+     inkscape:label="Ebene 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(-113.98819,-140.80081)">
+    <path
+       id="rect323-3"
+       style="fill:#ffffff;stroke:#44739e;stroke-width:1.5;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1"
+       d="m 124.2135,145.62023 11.36755,-0.008 -6.44343,15.66394 -11.78758,-0.006 z"
+       sodipodi:nodetypes="ccccc" />
+    <path
+       style="fill:none;stroke:#b6b6b6;stroke-width:0;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1"
+       d="m 119.99244,152.89751 4.42955,-4.2264"
+       id="path1624"
+       sodipodi:nodetypes="cc" />
+    <path
+       style="fill:none;stroke:#ffffff;stroke-width:0.5;stroke-linecap:round;stroke-linejoin:bevel;stroke-dasharray:none;stroke-opacity:1"
+       d="m 128.60176,159.95723 5.29854,-12.87884"
+       id="path1624-5-3-1"
+       sodipodi:nodetypes="cc" />
+    <path
+       d="m 126.628,153.13819 a 0.38177113,0.38177113 0 0 0 -0.38177,0.38176 0.38177113,0.38177113 0 0 0 0.38177,0.38177 0.38177113,0.38177113 0 0 0 0.38176,-0.38177 0.38177113,0.38177113 0 0 0 -0.38176,-0.38176 m 0.19088,-3.43595 c 1.71797,0 1.75997,1.36293 0.85898,1.81342 -0.37794,0.18706 -0.54592,0.58793 -0.61846,0.94297 0.18325,0.0763 0.34358,0.19471 0.46576,0.34741 1.41256,-0.76355 2.932,-0.46194 2.932,0.9048 0,1.71797 -1.36292,1.75616 -1.81341,0.85135 -0.19088,-0.37794 -0.59557,-0.54593 -0.95061,-0.61847 -0.0763,0.18325 -0.19471,0.33978 -0.34741,0.46959 0.75973,1.40873 0.45812,2.92435 -0.90862,2.92435 -1.71797,0 -1.75233,-1.36673 -0.85135,-1.81722 0.37414,-0.18707 0.54212,-0.58411 0.61847,-0.93534 -0.18706,-0.0763 -0.35122,-0.19852 -0.47339,-0.35124 -1.40874,0.75592 -2.92055,0.45813 -2.92055,-0.90479 0,-1.71798 1.35909,-1.75997 1.80958,-0.85517 0.19089,0.37795 0.59176,0.54211 0.94681,0.61465 0.0726,-0.18325 0.1947,-0.34359 0.35123,-0.46576 -0.75974,-1.40873 -0.45813,-2.92055 0.90097,-2.92055 z"
+       id="path1509"
+       style="fill:#44739e;fill-opacity:1;stroke-width:0.264583" />
+  </g>
+</svg>


### PR DESCRIPTION
Add nine new SVG assets under icon-svg/ for tilt cover and tilt window states: tilt-cover-{closed,closing,disabled,opened,opening}.svg and tilt-window-{closing,disabled,opening,venting}.svg. These Inkscape-created icons provide visual states (open/closed/opening/closing/venting/disabled) for cover/window UI elements.