### PR TITLE
Add support for building locally using docker compose

### DIFF
--- a/README.md
+++ b/README.md
@@ -287,6 +287,16 @@ Thanks to the work of @SoulSolistice, a `normalize-icons.mjs` has been introduce
 * Run `npm run clean:vrt` to clean the current icons (will be overwritten). Also creates `vrt.png` in the `scripts` folder as "Visual Regression Test". This needs ImageMagick installed.
 
 
+### Running locally using docker
+This repository contains a docker-compose file that performs the two tasks above:
+1. Runs the `node custom-icons-builder.cjs` script using node 22 to generate custom icons.
+2. Builds a local Docker image with node 22 and ImageMagick and then normalizes and cleans up the generated files using `npm run clean:vrt`.
+
+To perform these tasks, run one of the following commands:
+```sh
+docker compose up build
+docker compose up normalize --build
+```
 
 
 ### Contributions and Pull Requests

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,29 @@
+# This docker-compose file performs two tasks:
+# 1. Runs the `node custom-icons-builder.js` script to generate custom icons.
+# 2. Builds a local Docker image with node.js:22 ImageMagick and then normalizes and cleans up the generated files using `npm run clean:vrt`.
+#
+# To perform these tasks, run one of the following command:
+#   docker compose up build
+#   docker compose up normalize --build
+
+services:
+  build:
+    image: node:22
+    working_dir: /workspace
+    volumes:
+      - .:/workspace
+    command: >
+      node custom-icons-builder.cjs
+
+  normalize:
+    build:
+      context: .
+      dockerfile_inline: |
+        FROM node:22
+        RUN apt-get update -qq && apt-get install -y -qq imagemagick && rm -rf /var/lib/apt/lists/*
+    working_dir: /workspace
+    volumes:
+      - .:/workspace
+    command: >
+      sh -c "npm install &&
+             npm run clean:vrt"


### PR DESCRIPTION
This PR adds a docker compose file to enable compiling the library on a local disk using docker compose rather than installing node.

This also add some instructions in the readme file on how to use the docker-compose file.