### PR TITLE
Correct typo for command to run to generate local package

### DIFF
--- a/README.md
+++ b/README.md
@@ -246,7 +246,7 @@ Example svg file below:
 > [!WARNING]  
 >You need to have Node.js installed to use automatic generation.
 
-Go to the local folder where the `custom-icons-builder.js` file is located and run `node custom-icons-builder.js` The script will generate a new `custom brand-icons` file with the updated icons.
+Go to the local folder where the `custom-icons-builder.js` file is located and run `node custom-icons-builder.cjs` The script will generate a new `custom brand-icons` file with the updated icons.
 
 If everything went well you will see a message like this
 


### PR DESCRIPTION
This PR fixes the typo in the README file on which command to run to generate the new iconfile.