### PR TITLE
Close linked PRs when issue labeled or closed

### DIFF
--- a/.github/workflows/validate-issue-svg.yml
+++ b/.github/workflows/validate-issue-svg.yml
@@ -80,10 +80,10 @@ jobs:
                   return; // not the label we care about
                 }
                 shouldClose = true;
-                reason = `è stata marcata manualmente con l'etichetta \`${invalidLabel}\``;
+                reason = `was manually marked with the \`${invalidLabel}\` label`;
               } else if (context.payload.action === 'closed') {
                 shouldClose = true;
-                reason = 'è stata chiusa';
+                reason = 'was closed';
               }
 
               if (!shouldClose) return;
@@ -118,7 +118,7 @@ jobs:
                 await github.rest.pulls.update({ owner, repo, pull_number: pr_number, state: 'closed' });
                 await github.rest.issues.createComment({
                   owner, repo, issue_number: pr_number,
-                  body: `🔒 Questa PR è stata chiusa automaticamente perché la issue collegata #${issue_number} ${reason}.`
+                  body: `🔒 This PR was automatically closed because the linked issue #${issue_number} ${reason}.`
                 });
               }
 

--- a/.github/workflows/validate-issue-svg.yml
+++ b/.github/workflows/validate-issue-svg.yml
@@ -2,7 +2,7 @@ name: Validate and PR new icon
 
 on:
   issues:
-    types: [opened, edited]
+    types: [opened, edited, labeled, closed]
   workflow_dispatch:
     inputs:
       issue_number:
@@ -63,6 +63,65 @@ jobs:
                   });
                 }
               }
+              return;
+            }
+            // -----------------------------------------------------------------------
+
+            // ---------------- Close linked PR when issue is marked invalid or closed ----------------
+            if (context.eventName === 'issues' && (context.payload.action === 'labeled' || context.payload.action === 'closed')) {
+              const issue_number = context.issue.number;
+
+              let shouldClose = false;
+              let reason = '';
+
+              if (context.payload.action === 'labeled') {
+                const labelName = context.payload.label?.name;
+                if (labelName !== invalidLabel) {
+                  return; // not the label we care about
+                }
+                shouldClose = true;
+                reason = `è stata marcata manualmente con l'etichetta \`${invalidLabel}\``;
+              } else if (context.payload.action === 'closed') {
+                shouldClose = true;
+                reason = 'è stata chiusa';
+              }
+
+              if (!shouldClose) return;
+
+              // Find PR(s) linked to this issue via GitHub's own cross-reference
+              // timeline (populated automatically from "Closes #N" in the PR body —
+              // the same mechanism behind the "Linked pull requests" UI).
+              const timeline = await github.paginate(github.rest.issues.listEventsForTimeline, {
+                owner, repo, issue_number, per_page: 100
+              });
+
+              const linkedPRs = new Set();
+              for (const event of timeline) {
+                if (
+                  event.event === 'cross-referenced' &&
+                  event.source?.issue?.pull_request &&
+                  event.source.issue.repository?.full_name === `${owner}/${repo}`
+                ) {
+                  linkedPRs.add(event.source.issue.number);
+                }
+              }
+
+              if (linkedPRs.size === 0) {
+                console.log(`Nessuna PR collegata trovata per la issue #${issue_number}.`);
+                return;
+              }
+
+              for (const pr_number of linkedPRs) {
+                const { data: pr } = await github.rest.pulls.get({ owner, repo, pull_number: pr_number });
+                if (pr.state !== 'open') continue;
+
+                await github.rest.pulls.update({ owner, repo, pull_number: pr_number, state: 'closed' });
+                await github.rest.issues.createComment({
+                  owner, repo, issue_number: pr_number,
+                  body: `🔒 Questa PR è stata chiusa automaticamente perché la issue collegata #${issue_number} ${reason}.`
+                });
+              }
+
               return;
             }
             // -----------------------------------------------------------------------


### PR DESCRIPTION
Add 'labeled' and 'closed' issue events to the workflow and implement logic to automatically close linked pull requests when an issue is closed or labeled (e.g. marked invalid). The workflow scans the issue timeline for cross-referenced PRs, closes any open linked PRs, and posts an Italian-language comment explaining the automatic closure. Non-target labels are ignored.