### PR TITLE
Correct Contribution Policy

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -99,4 +99,4 @@ docker compose up normalize --build
 > **Contributions Rules:** All Pull Requests must be targeted to the `dev` branch. 
 > PRs opened against `main` will be automatically closed by our bot.
 
-After adding your svg icon in `icon-svg` folder . Open pull request on the **[dev branch](https://github.com/elax46/custom-brand-icons/pulls)**. You should create a **new feature branch** on your fork (e.g., `feat/add-new-icon`) and submit your PR from there.
+After adding your svg icon in `icon-svg` folder . Open pull request on the **[dev branch](https://github.com/elax46/custom-brand-icons/pulls)**. You must create a **new feature branch** on your fork (e.g., `feat/add-new-icon`) and submit your PR from there. Pull requests from a head branch named `main` or `dev` will be automatically closed.


### PR DESCRIPTION
The contributing guidelines incorrectly state that you "**_should_** create a new feature branch". It should state that you "**_must_** create a new feature branch". 

The [Strict Contribution Policy Enforcer](
https://github.com/elax46/custom-brand-icons/blob/94fc21c132a1d754e13885ac5ca893460855b291/.github/workflows/pr-enforcer.yml#L32) action rejects anything using `main` or `dev` automatically.